### PR TITLE
Adapting slurm to handle both packaging. Allow OpenHPC slurm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Currently supported OS are:
 
 Debian 9 and 10 are dropped for now because too much issues with the netboot part.
 
-Ansible **>= 2.8.2 is mandatory** for BlueBanquise to run properly.
+Ansible >= 2.8.2 is mandatory for BlueBanquise to run properly.
+
+**[OpenHPC](https://openhpc.community/downloads/)** scientific packages and OpenHPC slurm job scheduler are compatible with the stack.
+
 
 BlueBanquise is part of the **Algoric** Project from the [**Fabrique du Loch**](https://www.lafabriqueduloch.org/fr/accueil/) FabLab.
 

--- a/roles/ADDON_slurm/addon/slurm.yml
+++ b/roles/ADDON_slurm/addon/slurm.yml
@@ -1,4 +1,5 @@
 slurm:
+  slurm_packaging: after_17 # Can be before_17 or after_17. If using BlueBanquise packages, use after_17. For OpenHPC 1.3, use before_17.
   cluster_name: bluebanquise
   control_machine: management1
   nodes_equipment_groups:

--- a/roles/ADDON_slurm/tasks/main.yml
+++ b/roles/ADDON_slurm/tasks/main.yml
@@ -4,23 +4,7 @@
   package:
     name: "{{item}}"
     state: present
-  with_items:
-    - munge
-    - munge-libs
-    - slurm
-    - slurm-slurmctld
-  when: slurm_profile == 'controler'
-
-- name: Package
-  package:
-    name: "{{item}}"
-    state: present
-  with_items:
-    - munge
-    - munge-libs
-    - slurm
-    - slurm-slurmd
-  when: slurm_profile == 'node'
+  loop: "{{packages_to_install[slurm.slurm_packaging][slurm_profile][(ansible_distribution|lower|replace(' ','_'))]['_'+ansible_distribution_major_version]}}"
 
 #### MUNGE
 

--- a/roles/ADDON_slurm/vars/main.yml
+++ b/roles/ADDON_slurm/vars/main.yml
@@ -1,0 +1,107 @@
+role_version: 1.0.2
+
+packages_to_install:
+  before_17:
+    controller:
+      ubuntu:
+        _18:
+      centos:
+        _7:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+          - slurm-munge
+      redhat:
+        _8:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+          - slurm-munge
+    node:
+      ubuntu:
+        _18:
+      centos:
+        _7:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+          - slurm-munge
+      redhat:
+        _8:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+          - slurm-munge
+    passive:
+      ubuntu:
+        _18:
+      centos:
+        _7:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+          - slurm-munge
+      redhat:
+        _8:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+          - slurm-munge
+
+  after_17:
+    controller:
+      ubuntu:
+        _18:
+      centos:
+        _7:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+          - slurm-slurmctld
+      redhat:
+        _8:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+          - slurm-slurmctld
+    node:
+      ubuntu:
+        _18:
+      centos:
+        _7:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+          - slurm-slurmd
+      redhat:
+        _8:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+          - slurm-slurmd
+    passive:
+      ubuntu:
+        _18:
+      centos:
+        _7:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+      redhat:
+        _8:
+          - munge
+          - munge-libs
+          - slurm
+          - slurm-devel
+


### PR DESCRIPTION
Hello JK.

Someone asked for OpenHPC compatibility.

All HPC scientific packages from OpenHPC are autonomous, so ok for them. Only issue I see is with slurm version.

Then, BlueBanquise will be able to replace provisioning of OpenHPC, but be compatible with it's rpms.

Is it ok for you this way ?

Ox