### PR TITLE
Update role pxe_stack main.yml

### DIFF
--- a/roles/core/pxe_stack/tasks/main.yml
+++ b/roles/core/pxe_stack/tasks/main.yml
@@ -78,7 +78,7 @@
 - name: Templates >> kickstarts for Centos
   template:
     src: "kickstart.cfg.j2"
-    dest: /var/www/html/preboot_execution_environment/equipment_os_configurations/kickstart.{{item | replace(equipment_naming,'') | trim}}.cfg
+    dest: /var/www/html/preboot_execution_environment/equipment_os_configurations/kickstart.{{item | replace(equipment_naming+'_','') | trim}}.cfg
     mode: 0644
   with_items: "{{ j2_equipment_groups_list }}"
   when:
@@ -90,7 +90,7 @@
 - name: Templates >> equipment_ipxe_configurations for Centos
   template:
     src: configuration_centos.ipxe.j2
-    dest: /var/www/html/preboot_execution_environment/equipment_ipxe_configurations/{{item | replace(equipment_naming,'') | trim}}.ipxe
+    dest: /var/www/html/preboot_execution_environment/equipment_ipxe_configurations/{{item | replace(equipment_naming+'_','') | trim}}.ipxe
     mode: 0644
   with_items: "{{j2_equipment_groups_list}}"
   when:
@@ -104,7 +104,7 @@
 - name: Templates >> preseeds for Ubuntu
   template:
     src: "preseed.cfg.j2"
-    dest: /var/www/html/preboot_execution_environment/equipment_os_configurations/preseed.{{item | replace(equipment_naming,'') | trim}}.cfg
+    dest: /var/www/html/preboot_execution_environment/equipment_os_configurations/preseed.{{item | replace(equipment_naming+'_','') | trim}}.cfg
     mode: 0644
   with_items: "{{j2_equipment_groups_list}}"
   when:
@@ -116,7 +116,7 @@
 - name: Templates >> equipment_ipxe_configurations for Ubuntu
   template:
     src: "configuration_ubuntu.ipxe.j2"
-    dest: /var/www/html/preboot_execution_environment/equipment_ipxe_configurations/{{item | replace(equipment_naming,'') | trim}}.ipxe
+    dest: /var/www/html/preboot_execution_environment/equipment_ipxe_configurations/{{item | replace(equipment_naming+'_','') | trim}}.ipxe
     mode: 0644
   with_items: "{{j2_equipment_groups_list}}"
   when:
@@ -130,7 +130,7 @@
 - name: Templates >> autoyasts for OpenSuse
   template:
     src: "autoyast.xml.j2"
-    dest: /var/www/html/preboot_execution_environment/equipment_os_configurations/autoyast.{{item | replace(equipment_naming,'') | trim}}.xml
+    dest: /var/www/html/preboot_execution_environment/equipment_os_configurations/autoyast.{{item | replace(equipment_naming+'_','') | trim}}.xml
     mode: 0644
   with_items: "{{j2_equipment_groups_list}}"
   when:
@@ -142,7 +142,7 @@
 - name: Templates >> equipment_ipxe_configurations for OpenSuse
   template:
     src: "configuration_opensuse.ipxe.j2"
-    dest: /var/www/html/preboot_execution_environment/equipment_ipxe_configurations/{{item | replace(equipment_naming,'') | trim}}.ipxe
+    dest: /var/www/html/preboot_execution_environment/equipment_ipxe_configurations/{{item | replace(equipment_naming+'_','') | trim}}.ipxe
     mode: 0644
   with_items: "{{j2_equipment_groups_list}}"
   when:


### PR DESCRIPTION
Hi,

In '/var/www/html/preboot_execution_environment/equipment_ipxe_configurations/' directory
[root@mngt0-1 ]# ll /var/www/html/preboot_execution_environment/equipment_ipxe_configurations/
total 20
-rw-r--r--. 1 apache apache 427 Nov 28 11:12 minimal.ipxe
-rwxr-xr-x. 1 apache apache 891 Nov 28 11:44 _typeC.ipxe
-rwxr-xr-x. 1 apache apache 961 Nov 28 11:12 _typeM.ipxe

The *.ipxe file generated by the template isn't correct.
I have fixed it with this patch.

Best regards