### PR TITLE
advanced_dhcp_server role fails with opt61

### DIFF
--- a/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -46,7 +46,7 @@
         {% elif nic_args.dhcp_client_identifier is defined and not none %}
   host {{host}} {
     option host-name "{{host}}";
-    option dhcp_client_identifier {{nic_args.dhcp-client-identifier}};
+    option dhcp-client-identifier {{nic_args.dhcp_client_identifier}};
     fixed-address {{nic_args.ip4}};
     filename "{{ipxe_rom_filename}}";
   }
@@ -85,7 +85,7 @@
         {% elif bmc_args.dhcp_client_identifier is defined and not none %}
   host {{bmc_args.name}} {
     option host-name "{{bmc_args.name}}";
-    option dhcp_client_identifier {{bmc_args.dhcp-client-identifier}};
+    option dhcp-client-identifier {{bmc_args.dhcp_client_identifier}};
     fixed-address {{bmc_args.ip4}};
   }
         {% elif bmc_args.host_identifier is defined and not none %}


### PR DESCRIPTION
Hi,
When I write an inventory file that describes the options 61, I have issue:
```
failed: [mngt0-1] (item=ice1-1) => changed=false
  ansible_loop_var: item
  item: ice1-1
  msg: 'AnsibleUndefinedVariable: ''dict object'' has no attribute ''dhcp'''
```
I have fixed this issue like this.

Kind regards