### PR TITLE
fail during the UEFI node boot phase

### DIFF
--- a/roles/core/pxe_stack/templates/menu.ipxe.j2
+++ b/roles/core/pxe_stack/templates/menu.ipxe.j2
@@ -87,7 +87,7 @@ iseq ${platform} efi && goto bootdisk-efi || goto bootdisk-legacy
     :bootdisk-efi
     echo Booting on disk in EFI way
     sleep 2
-    chain http://${next-server}/preboot_execution_environment/bin/grub2_efi_autofind.img || shell
+    chain http://${next-server}/preboot_execution_environment/bin/x86_64/grub2_efi_autofind.img || shell
     exit 1
 
 :memtest


### PR DESCRIPTION
Hi,
http://10.0.0.240/preboot_execution_environment/bin/grub2_efi_autofind.img... No such file or directory (http://ipxe.org/2d0c618e)
Regards