### PR TITLE
Fix: rename of system_repositories in tasks

### DIFF
--- a/roles/core/repositories_client/tasks/centos_7.yml
+++ b/roles/core/repositories_client/tasks/centos_7.yml
@@ -6,4 +6,4 @@
     description: "{{item}} gen by Ansible"
     baseurl: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/{{item}}"
     gpgcheck: no
-  with_items: "{{system_repositories}}"
+  with_items: "{{ repositories }}"

--- a/roles/core/repositories_client/tasks/opensuse_leap_15.yml
+++ b/roles/core/repositories_client/tasks/opensuse_leap_15.yml
@@ -8,4 +8,4 @@
     #    repo: "http://{{networks[node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/{{item}}"
     disable_gpg_check: yes
     state: present
-  with_items: "{{system_repositories}}"
+  with_items: "{{ repositories }}"

--- a/roles/core/repositories_client/tasks/redhat_7.yml
+++ b/roles/core/repositories_client/tasks/redhat_7.yml
@@ -6,4 +6,4 @@
     description: "{{item}} gen by Ansible"
     baseurl: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/{{item}}"
     gpgcheck: no
-  with_items: "{{system_repositories}}"
+  with_items: "{{ repositories }}"

--- a/roles/core/repositories_client/tasks/redhat_8.yml
+++ b/roles/core/repositories_client/tasks/redhat_8.yml
@@ -6,7 +6,7 @@
     description: "{{ item }} gen by Ansible"
     baseurl: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/{{item}}"
     gpgcheck: no
-  loop: "{{ system_repositories }}"
+  loop: "{{ repositories }}"
   when: item != 'os'
 
 - name: "Setting repositories os ({{ item }})"
@@ -18,7 +18,7 @@
   loop:
     - BaseOS
     - AppStream
-  when: "'os' in system_repositories"
+  when: "'os' in repositories"
 
 - name: "Setting external repository ({{ item }})"
   yum_repository:

--- a/roles/core/repositories_client/tasks/ubuntu_18.yml
+++ b/roles/core/repositories_client/tasks/ubuntu_18.yml
@@ -4,4 +4,4 @@
   apt_repository:
     repo: "deb http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/{{item}} bionic main"
     state: present
-  with_items: "{{system_repositories}}"
+  with_items: "{{ repositories }}"


### PR DESCRIPTION
Commit d60214be replaced system_repositories with repositories in the
examples and tasks for CentOS 8. Update the repositories_client tasks
for other OS as well.