### PR TITLE
Feat: make yum repositories more configurable

### DIFF
--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/external.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/external.yml
@@ -22,7 +22,8 @@ external_hosts:
 # Be aware that, at this level, theses repositories will be exported on all hosts without
 # any architecture or distribution check.
 
-external_repositories:
+#external_repositories:
 #  - name: epel
-#    url: 'https://dl.fedoraproject.org/pub/epel/7/x86_64/'
+#    baseurl: 'https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/'
+#    proxy: 'https://proxy:8080'
 

--- a/roles/core/repositories_client/tasks/centos_7.yml
+++ b/roles/core/repositories_client/tasks/centos_7.yml
@@ -1,9 +1,16 @@
 ---
 
+- name: Set baseurl prefix
+  set_fact:
+    baseurl_prefix: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/"
+
 - name: Setting repositories
   yum_repository:
-    name: "{{item}}"
-    description: "{{item}} gen by Ansible"
-    baseurl: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/{{item}}"
-    gpgcheck: no
-  with_items: "{{ repositories }}"
+    name: "{{ item.name | default(item) }}"
+    description: "{{ item.name | default(item) }} gen by Ansible"
+    baseurl: "{{ item.baseurl | default(baseurl_prefix + item.name | default(item)) }}"
+    enabled: "{{ item.enabled | default(1) }}"
+    gpgcheck: "{{ item.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.gpgkey | default(omit) }}"
+    proxy: "{{ item.proxy | default(omit) }}"
+  with_items: "{{ repositories | union(external_repositories|default([])) }}"

--- a/roles/core/repositories_client/tasks/centos_8.yml
+++ b/roles/core/repositories_client/tasks/centos_8.yml
@@ -1,34 +1,29 @@
 ---
 
+- name: Set baseurl prefix
+  set_fact:
+    baseurl_prefix: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/"
+
 - name: Setting repositories
   yum_repository:
-    name: "{{ item }}"
-    description: "{{ item }} gen by Ansible"
-    baseurl: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/{{item}}"
-    gpgcheck: no
-  loop: "{{ repositories }}"
-  when: item != 'os'
+    name: "{{ item.name | default(item) }}"
+    description: "{{ item.name | default(item) }} gen by Ansible"
+    baseurl: "{{ item.baseurl | default(baseurl_prefix + item.name | default(item)) }}"
+    enabled: "{{ item.enabled | default(1) }}"
+    gpgcheck: "{{ item.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.gpgkey | default(omit) }}"
+    proxy: "{{ item.proxy | default(omit) }}"
+  with_items: "{{ repositories | union(external_repositories|default([])) }}"
+  when: ( item != 'os' ) and ( item.name is not defined or item.name != 'os' )
 
-- name: "Setting repositories os ({{ item }})"
+- name: "Setting repositories os ({{ item.1 }})"
   yum_repository:
-    name: "{{ item }}"
-    description: "{{ item }} gen by Ansible"
-    baseurl: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/os/{{ item }}"
-    gpgcheck: no
-  loop:
-    - BaseOS
-    - AppStream
-  when: "'os' in repositories"
-
-- name: "Setting external repository ({{ item }})"
-  yum_repository:
-    name: "{{ item.name }}"
-    description: "{{ item.name }} gen by Ansible"
-    baseurl: "{{ item.url }}"
-    gpgcheck: no
-  with_items: "{{ external_repositories }}"
-  when:
-    - external_repositories is defined
-    - external_repositories is not none
-    - external_repositories
-    - external_repositories is iterable
+    name: "{{ item.1 }}"
+    description: "{{ item.1 }} gen by Ansible"
+    baseurl: "{{ item.0.baseurl | default(baseurl_prefix + 'os/' + item.1) }}"
+    enabled: "{{ item.0.enabled | default(1) }}"
+    gpgcheck: "{{ item.0.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.0.gpgkey | default(omit) }}"
+    proxy: "{{ item.0.proxy | default(omit) }}"
+  loop: "{{ repositories | product(['AppStream', 'BaseOS']) | list }}"
+  when: ( item.0 == 'os' ) or ( item.0.name is defined and item.0.name == 'os' )

--- a/roles/core/repositories_client/tasks/redhat_7.yml
+++ b/roles/core/repositories_client/tasks/redhat_7.yml
@@ -1,9 +1,16 @@
 ---
 
+- name: Set baseurl prefix
+  set_fact:
+    baseurl_prefix: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/"
+
 - name: Setting repositories
   yum_repository:
-    name: "{{item}}"
-    description: "{{item}} gen by Ansible"
-    baseurl: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/{{item}}"
-    gpgcheck: no
-  with_items: "{{ repositories }}"
+    name: "{{ item.name | default(item) }}"
+    description: "{{ item.name | default(item) }} gen by Ansible"
+    baseurl: "{{ item.baseurl | default(baseurl_prefix + item.name | default(item)) }}"
+    enabled: "{{ item.enabled | default(1) }}"
+    gpgcheck: "{{ item.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.gpgkey | default(omit) }}"
+    proxy: "{{ item.proxy | default(omit) }}"
+  with_items: "{{ repositories | union(external_repositories|default([])) }}"

--- a/roles/core/repositories_client/tasks/redhat_8.yml
+++ b/roles/core/repositories_client/tasks/redhat_8.yml
@@ -1,29 +1,29 @@
 ---
 
+- name: Set baseurl prefix
+  set_fact:
+    baseurl_prefix: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/"
+
 - name: Setting repositories
   yum_repository:
-    name: "{{ item }}"
-    description: "{{ item }} gen by Ansible"
-    baseurl: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/{{item}}"
-    gpgcheck: no
-  loop: "{{ repositories }}"
-  when: item != 'os'
+    name: "{{ item.name | default(item) }}"
+    description: "{{ item.name | default(item) }} gen by Ansible"
+    baseurl: "{{ item.baseurl | default(baseurl_prefix + item.name | default(item)) }}"
+    enabled: "{{ item.enabled | default(1) }}"
+    gpgcheck: "{{ item.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.gpgkey | default(omit) }}"
+    proxy: "{{ item.proxy | default(omit) }}"
+  with_items: "{{ repositories | union(external_repositories|default([])) }}"
+  when: ( item != 'os' ) and ( item.name is not defined or item.name != 'os' )
 
-- name: "Setting repositories os ({{ item }})"
+- name: "Setting repositories os ({{ item.1 }})"
   yum_repository:
-    name: "{{ item }}"
-    description: "{{ item }} gen by Ansible"
-    baseurl: "http://{{networks[j2_node_main_network]['services_ip']['repository_ip']}}/repositories/{{equipment_profile['operating_system']['distribution']}}/{{equipment_profile['operating_system']['distribution_version']}}/{{equipment_profile['hardware']['cpu']['architecture']}}/os/{{ item }}"
-    gpgcheck: no
-  loop:
-    - BaseOS
-    - AppStream
-  when: "'os' in repositories"
-
-- name: "Setting external repository ({{ item }})"
-  yum_repository:
-    name: "{{ item.name }}"
-    description: "{{ item.name }} gen by Ansible"
-    baseurl: "{{ item.url }}"
-    gpgcheck: no
-  loop: "{{ external_repositories | default([]) }}"
+    name: "{{ item.1 }}"
+    description: "{{ item.1 }} gen by Ansible"
+    baseurl: "{{ item.0.baseurl | default(baseurl_prefix + 'os/' + item.1) }}"
+    enabled: "{{ item.0.enabled | default(1) }}"
+    gpgcheck: "{{ item.0.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.0.gpgkey | default(omit) }}"
+    proxy: "{{ item.0.proxy | default(omit) }}"
+  loop: "{{ repositories | product(['AppStream', 'BaseOS']) | list }}"
+  when: ( item.0 == 'os' ) or ( item.0.name is defined and item.0.name == 'os' )


### PR DESCRIPTION
Allow to modify some settings for the repo, be it a system repository or
an external repository.

List of settings: name, baseurl, enabled, gpgcheck, gpgkey and proxy.

System repositories, internal to the cluster, can use the same
configuration syntax than previously:

  repositories:
    - bluebanquise
    - os

It can be expanded to change settings for a repo with a dict, using
YAML's flow styles or block styles:

  repositories:
    - bluebanquise
    - { name: 'os', gpgcheck: 1 }  # Flow style
    - name: epel                   # Block style
      gpgcheck: 1

Additional repositories can either be added to the repositories.yml or
external.yml configuration files, to logically segregate internal and
external repositories.

  external_repositories:
    - name: epel
      baseurl: 'https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/'
      proxy: 'https://proxy:8080'