### PR TITLE
Fix: replace symlinks from simple_cluster examples

### DIFF
--- a/resources/examples/simple_cluster/inventory/group_vars/all/all_equipments
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/all_equipments
@@ -1,1 +1,0 @@
-../../../../multi_icebergs_cluster/inventory/group_vars/all/all_equipments

--- a/resources/examples/simple_cluster/inventory/group_vars/all/all_equipments/authentication.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/all_equipments/authentication.yml
@@ -1,0 +1,8 @@
+authentication:
+  # Root password to be used on deployed hosts
+  root_password_sha512: $6$M3crarMVoUV3rALd$ZTre2CIyss7zOb4lkLoG23As9OAkYPw2BM88Y1F43n8CCyV5XWwAYEwBOrS8bcCBIMjIPdJG.ndOfzWyAVR4j0 # This password is 'root', change it!
+
+  # SSH public keys to be added as authorized keys on deployed/managed hosts
+  ssh_keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDodjKUXHm1K7HkQ8rgyXDfOAW9wvWHz24+YpkNGO0wI/jS0E44F4pdfNSqUWfLfBwwyiJ/+iLQAcJZjrQ1CnECNtImpHNRuMVH6shXX99oYRDOfJ8/MV89zrAe/KDUR677/j1dHYIS1fGzOzsxey00n+2c4LqxiFvwEIOGkB6W96aIQTx+V7eTxMegYrNttlh9eSR8yr8n4+0qk29wVVvtMysEUIt1z12dtqOr7lBuXhOy9EIUz+EZpPyXFrJiNBaKFpZBJXjzzRwR0uplyH5qf3tb3vgIxgHDPKiYRIOf3Caa9XAgmE1BU+R36wvLoS2z58ELQekJeO5z7TpsxXeB root@localhost.localdomain
+

--- a/resources/examples/simple_cluster/inventory/group_vars/all/all_equipments/equipment_profile.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/all_equipments/equipment_profile.yml
@@ -1,0 +1,46 @@
+equipment_profile:
+
+  # iPXE network driver
+  # default should be good for most of NIC, but some need SNP. Refer to http://ipxe.org/appnote/buildtargets for more information.
+  ipxe_driver: default # default or snp or snponly
+  ipxe_platform: pcbios # can be pcbios (for legacy/bios) or efi
+  ipxe_embed: standard # can be standard or dhcpretry
+
+  # When installing in EFI, grub2 break the boot order and set next boot to disk (seriously, why??!)
+  # In most case, you prefer system to continue to boot on PXE, and so the stack can restore first boot device after grub2 installation
+  preserve_efi_first_boot_device: true # true or false
+
+  console:
+  kernel_parameters:
+
+  access_control: true # Selinux, AppArmor, etc. Selinux: true = enforcing, false = disabled
+  firewall: true # Enable or disable native firewall
+
+  partitioning: | # Please provide native distribution partitioning. This example is for Centos/RedHat systems.
+    clearpart --all --initlabel
+    autopart --type=plain --fstype=ext4 --nohome
+
+  operating_system:
+    distribution: centos # centos, redhat, debian, ubuntu, opensuse, etc.
+    distribution_major_version: 8
+    distribution_version: 8.0
+
+  equipment_type: none  # If server, a pxe profile will be generated
+
+  configuration:
+    keyboard_layout: us # us, fr, etc.
+    system_language: en_US.UTF-8 # You should not update this if you want to google issues...
+
+  hardware:
+    cpu:
+      architecture: x86_64 # Can be x86_64 or arm64
+      cores: 1             # Mainly for slurm, but optional. You can define here detailed information on the CPUs.
+      cores_per_socket: 1
+      sockets: 1
+      threads_per_core: 1
+    gpu:
+
+  equipment_authentication: # login/password for BMC, storage bay controller, switch, etc.
+    user: ADMIN
+    password: ADMIN
+

--- a/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables
@@ -1,1 +1,0 @@
-../../../../multi_icebergs_cluster/inventory/group_vars/all/j2_variables

--- a/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/README.md
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/README.md
@@ -1,0 +1,10 @@
+# BlueBanquise internal j2_ variables.
+# (c) 2019 Benoit Leveugle
+
+These files contains j2 variables.
+
+:rotating_light: DO NOT EDIT THEM!!!! :rotating_light:
+
+Only edit if you know what you are doing.
+
+If a variable does not provide the correct output, or not the desired one, do not edit it, but use Ansible variables precedence mechanism to force your own value, as these j2_ variables are at the bottom of precedence priority.

--- a/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/accelerated_mode.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/accelerated_mode.yml
@@ -1,0 +1,5 @@
+# BlueBanquise internal j2_ variables.
+# Accelerated mode
+# (c) 2019 Benoit Leveugle
+
+j2_master_groups_list: "{{ groups | select('match','^'+master_groups_naming+'_.*') | list | unique | sort }}"

--- a/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/equipment.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/equipment.yml
@@ -1,0 +1,5 @@
+# BlueBanquise internal j2_ variables.
+# Equipment
+# (c) 2019 Benoit Leveugle
+
+j2_equipment_groups_list: "{{ groups | select('match','^'+equipment_naming+'_.*') | list | unique | sort }}"

--- a/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/icebergs.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/icebergs.yml
@@ -1,0 +1,35 @@
+# BlueBanquise internal j2_ variables.
+# Icebergs
+# (c) 2019 Benoit Leveugle
+
+## Icebergs engine file
+# To comply with KISS, all iceberg variables must depend of j2_current_iceberg when possible
+
+# General data
+j2_icebergs_groups_list: "{{ groups | select('match','^'+iceberg_naming+'[0-9]+') | list }}"
+j2_number_of_icebergs: "{{ groups | select('match','^'+iceberg_naming+'[0-9]+') | list | length }}"
+
+# Get host current iceberg
+# This is MAIN variable, and must remain as the chain is simple
+j2_current_iceberg: "{% if icebergs_system == false %}{{iceberg_naming+'1'}}{% else %}{{ group_names | select('match','^'+iceberg_naming+'[0-9]+') | list | unique | sort | first | join}}{% endif %}"
+
+# Now deduced from j2_current_iceberg
+
+#      _____
+#     |     |
+#     |     |
+#     |     |
+#   __|     |__
+#   \         /
+#    \       /
+#     \     /
+#      \   /
+#       \ /
+#        '
+
+j2_current_iceberg_number: "{{ j2_current_iceberg | replace(iceberg_naming,' ') | trim }}"
+
+# Network related
+j2_current_iceberg_network: "{{management_networks_naming + (j2_current_iceberg_number|string)}}"
+
+

--- a/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/internal_variables.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/internal_variables.yml
@@ -1,0 +1,9 @@
+### NAMING
+
+iceberg_naming: iceberg
+equipment_naming: equipment
+management_networks_naming: ice
+master_groups_naming: mg
+
+managements_group_name: mg_managements
+

--- a/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/network.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/j2_variables/network.yml
@@ -1,0 +1,7 @@
+# BlueBanquise internal j2_ variables.
+# Network
+# (c) 2019 Benoit Leveugle
+
+j2_node_main_network: "{% set main_ntw = [] %}{% for nic in network_interfaces %}{% if network_interfaces[nic].network is defined and not none %}{{ main_ntw.append(network_interfaces[nic].network|string) }}{% endif %}{% endfor %}{{main_ntw | select('match',(j2_current_iceberg_network+'-[0-9]+')) | list | unique | sort| first | join | trim}}"
+
+j2_node_main_network_interface: "{% set main_ntw_nic = [] %}{% for nic in network_interfaces %}{% if network_interfaces[nic].network is defined and not none %}{% if network_interfaces[nic].network == j2_node_main_network %}{{ main_ntw_nic.append(nic|string) }}{% endif %}{% endif %}{% endfor %}{{main_ntw_nic | unique | join | trim}}"


### PR DESCRIPTION
Commit 4c24c8f7 introduced two symbolic links in the simple_cluster
inventory, with relative paths to the multi_icebergs_cluster inventory.

The "Configure BlueBanquise" documentation provides commands to copy the
simple_cluster inventory as the new inventory. Doing so breaks the
relative symlinks and makes the inventory unusable.

This commit fixes this by removing the symlinks and copying the
directories of the multi_icebergs_cluster inventory to the
simple_cluster inventory.