### PR TITLE
Feature: alternate next-server for HTTP/iPXE

### DIFF
--- a/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.networks.conf.j2
+++ b/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.networks.conf.j2
@@ -36,7 +36,16 @@ subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} 
   default-lease-time {{dhcp_settings['default_lease_time']}};
   max-lease-time {{dhcp_settings['max_lease_time']}};
 {% if networks[network]['services_ip']['pxe_ip'] is defined and not none %}
+{% if (networks[network]['services_ip']['pxe_http_ip'] is defined and not none)
+    and (networks[network]['services_ip']['pxe_http_ip'] != networks[network]['services_ip']['pxe_ip']) %}
+  if exists user-class and option user-class = "BlueBanquise" {
+    next-server {{networks[network]['services_ip']['pxe_http_ip']}};
+  } else {
+    next-server {{networks[network]['services_ip']['pxe_ip']}};
+  }
+{% else %}
   next-server {{networks[network]['services_ip']['pxe_ip']}};
+{% endif %}
 {% endif %}
 
   include "/etc/dhcp/dhcpd.{{network}}.conf";
@@ -65,7 +74,18 @@ subnet {{networks[network]['subnet']}} netmask {{networks[network]['netmask']}} 
 
   default-lease-time {{dhcp_settings['default_lease_time']}};
   max-lease-time {{dhcp_settings['max_lease_time']}};
-  {% if networks[network]['services_ip']['pxe_ip'] is defined and not none %}next-server {{networks[network]['services_ip']['pxe_ip']}};{% endif %}
+{% if networks[network]['services_ip']['pxe_ip'] is defined and not none %}
+{% if (networks[network]['services_ip']['pxe_http_ip'] is defined and not none)
+    and (networks[network]['services_ip']['pxe_http_ip'] != networks[network]['services_ip']['pxe_ip']) %}
+  if exists user-class and option user-class = "BlueBanquise" {
+    next-server {{networks[network]['services_ip']['pxe_http_ip']}};
+  } else {
+    next-server {{networks[network]['services_ip']['pxe_ip']}};
+  }
+{% else %}
+  next-server {{networks[network]['services_ip']['pxe_ip']}};
+{% endif %}
+{% endif %}
 
   include "/etc/dhcp/dhcpd.{{network}}.conf";
 


### PR DESCRIPTION
By default, the pxe_ip defines the next-server to use for both the TFTP
and HTTP/iPXE services which muse be hosted on the same server.

It is now possible to use a different next-server for HTTP/iPXE by
defining a new service parameter pxe_http_ip, thus the HTTP server for
ipxe scripts can be run on a separate server than the TFTP service.

The PXE chain remains unchanged: the first next-server obtained at boot
time is pxe_ip and it allows to load the iPXE bluebanquise ROM through
TFTP. This ROM will send a new request to the DHCP to get the
next-server to use for the HTTP/iPXE service. If pxe_http_ip is set,
then this is the IP address that will be used as next-server. Otherwise,
the default will be the pxe_ip.

Solve #60.