### PR TITLE
Need script and directory tags in pxe_stack role

### DIFF
--- a/roles/core/pxe_stack/tasks/main.yml
+++ b/roles/core/pxe_stack/tasks/main.yml
@@ -19,6 +19,8 @@
    - /var/www/cgi-bin
    - /etc/bluebanquise
    - /etc/bluebanquise/pxe
+  tags:
+    - directory
 
 - name: Create pxe directories structure
   file:
@@ -33,6 +35,8 @@
    - /var/www/html/preboot_execution_environment/nodes
    - /var/www/html/preboot_execution_environment/equipment_profiles
    - /var/www/html/preboot_execution_environment/osdeploy
+  tags:
+    - directory
 
 - name: Configure access on directory /var/www/html/preboot_execution_environment"
   file:
@@ -211,6 +215,8 @@
     mode: 0744
     owner: "{{ apache_user[(ansible_distribution|lower|replace(' ','_'))]['_'+ansible_distribution_major_version] }}"
     group: "{{ apache_user[(ansible_distribution|lower|replace(' ','_'))]['_'+ansible_distribution_major_version] }}"
+  tags:
+    - script
 
 - meta: flush_handlers
 


### PR DESCRIPTION
When deploying services like dhcp, tftp, http, dns etc. inside containers running on various bare metal nodes, we used the ansible "chroot" connector to generate the configuration files on a shared file system mounted on all nodes.
We want to use the standard roles (dhcp, dns, pxe_stack ...) for that purpose, but we do NOT want to start the services on the bare metal management node. So we use the template tag , but we need also for pxe_stack role to create the output directories and to copy the bootswitch cgi script. So, a directory and a script tag are needed for that.