### PR TITLE
ci: add workflow for static code analysis

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -24,10 +24,10 @@ jobs:
         run: pip install ansible ansible-lint flake8
 
       - name: Check python code
-        run: flake8 . --statistics
+        run: flake8 . --statistics --ignore E501,E226
 
       - name: Run linter on core and advanced-core roles
-        run: ansible-lint -v roles/{core,advanced-core}/*
+        run: ansible-lint -v roles/{core,advanced-core}/* -x 204
 
       - name: Run linter on example playbooks
         run: ansible-lint -v resources/examples/simple_cluster/playbooks/*.yml

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,33 @@
+name: Static code analysis
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  check:
+    name: Run static code analysis tools
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup python environment
+        uses: actions/setup-python@v1
+
+      - name: Install packages
+        run: pip install ansible ansible-lint flake8
+
+      - name: Check python code
+        run: flake8 . --statistics
+
+      - name: Run linter on core and advanced-core roles
+        run: ansible-lint -v roles/{core,advanced-core}/*
+
+      - name: Run linter on example playbooks
+        run: ansible-lint -v resources/examples/simple_cluster/playbooks/*.yml

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -5,9 +5,11 @@ on:
       - master
     paths-ignore:
       - '**.md'
+      - '**.rst'
   pull_request:
     paths-ignore:
       - '**.md'
+      - '**.rst'
 
 jobs:
   check:


### PR DESCRIPTION
Use GitHub Actions to run a workflow for static code analysis.
The workflow runs ansible-lint and flake8. Some tests are ignored for now.