### PR TITLE
fix: comment external_repositories

### DIFF
--- a/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/external.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/external.yml
@@ -21,7 +21,8 @@ external_hosts:
 # Be aware that, at this level, theses repositories will be exported on all hosts without
 # any architecture or distribution check.
 
-external_repositories:
+#external_repositories:
 #  - name: epel
-#    url: 'https://dl.fedoraproject.org/pub/epel/7/x86_64/'
+#    baseurl: 'https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/'
+#    proxy: 'https://proxy:8080'
 


### PR DESCRIPTION
With commit ec9e900c, the external_repositories should either be undefined, or defined with repositories configuration. I forgot to update the simple_cluster examples.