### PR TITLE
feat: Disable CentOS distro repositories

### DIFF
--- a/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/repositories.yml
+++ b/resources/examples/multi_icebergs_cluster/inventory/group_vars/all/general_settings/repositories.yml
@@ -2,3 +2,4 @@ repositories:
   - bluebanquise
   - os
 
+remove_distro_repositories: True

--- a/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/repositories.yml
+++ b/resources/examples/simple_cluster/inventory/group_vars/all/general_settings/repositories.yml
@@ -1,3 +1,5 @@
 repositories:
   - bluebanquise
   - os
+
+remove_distro_repositories: True

--- a/roles/core/repositories_client/handlers/main.yml
+++ b/roles/core/repositories_client/handlers/main.yml
@@ -1,0 +1,5 @@
+# Handler to clean yum metadata cache
+- name: yum-clean-metadata
+  command: yum clean metadata
+  args:
+    warn: no

--- a/roles/core/repositories_client/tasks/centos_7.yml
+++ b/roles/core/repositories_client/tasks/centos_7.yml
@@ -1,5 +1,16 @@
 ---
 
+- name: Disable CentOS-Base distro repositories
+  ini_file:
+    path: "/etc/yum.repos.d/CentOS-Base.repo"
+    section: "{{ item }}"
+    option: enabled
+    value: '0'
+    no_extra_spaces: yes
+  loop: [ 'base', 'updates', 'extras' ]
+  when: remove_distro_repositories is defined and remove_distro_repositories
+  notify: yum-clean-metadata
+
 - name: Set baseurl prefix
   set_fact:
     baseurl_prefix: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ equipment_profile['operating_system']['distribution'] }}/{{ equipment_profile['operating_system']['distribution_version'] }}/{{ equipment_profile['hardware']['cpu']['architecture'] }}/"

--- a/roles/core/repositories_client/tasks/centos_8.yml
+++ b/roles/core/repositories_client/tasks/centos_8.yml
@@ -1,5 +1,19 @@
 ---
 
+- name: Disable CentOS distro repositories
+  ini_file:
+    path: "/etc/yum.repos.d/{{ item.file }}.repo"
+    section: "{{ item.section }}"
+    option: enabled
+    value: '0'
+    no_extra_spaces: yes
+  with_items:
+    - { file: CentOS-AppStream, section: AppStream }
+    - { file: CentOS-Base, section: BaseOS }
+    - { file: CentOS-Extras, section: extras }
+  when: remove_distro_repositories is defined and remove_distro_repositories
+  notify: yum-clean-metadata
+
 - name: Set baseurl prefix
   set_fact:
     baseurl_prefix: "http://{{ networks[j2_node_main_network]['services_ip']['repository_ip'] }}/repositories/{{ equipment_profile['operating_system']['distribution'] }}/{{ equipment_profile['operating_system']['distribution_version'] }}/{{ equipment_profile['hardware']['cpu']['architecture'] }}/"


### PR DESCRIPTION
This feature allows to disable the CentOS repositories enabled by
default after the installation of the OS. It can be enabled or disabled
with the boolean parameter remove_distro_repositories.

If the parameter is not defined, the repositories are untouched to keep
current behavior. In the examples, the parameter defaults to True
because it is good practice to set up a local mirror when we have a lot
of systems.