### PR TITLE
feat: create wrapper command bluebanquise-playbook

### DIFF
--- a/bluebanquise.spec
+++ b/bluebanquise.spec
@@ -81,6 +81,8 @@ cp -aL roles/core %{buildroot}%{_sysconfdir}/%{name}/roles/
 cp -aL roles/advanced-core %{buildroot}%{_sysconfdir}/%{name}/roles/
 cp -aL roles/addons %{buildroot}%{_sysconfdir}/%{name}/roles/
 mkdir -p %{buildroot}%{_sysconfdir}/%{name}/roles/customs
+mkdir -p %{buildroot}%{_sbindir}
+cp -a tools/bluebanquise-playbook %{buildroot}%{_sbindir}/
 
 
 %files -f rolesfiles.cores
@@ -90,6 +92,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/%{name}/roles/customs
 %dir %{_sysconfdir}/%{name}/
 %config(noreplace) %{_sysconfdir}/%{name}/ansible.cfg
 %{_sysconfdir}/%{name}/roles/customs/
+%attr(750,root,root) %{_sbindir}/bluebanquise-playbook
 
 
 # Create subpackages for each addon role

--- a/tools/bluebanquise-playbook
+++ b/tools/bluebanquise-playbook
@@ -1,0 +1,60 @@
+#!/usr/bin/bash
+
+export ANSIBLE_CONFIG=/etc/bluebanquise
+
+usage() {
+    echo "Usage:
+ $(basename $0) -l
+ $(basename $0) -p <playbook> [-n <nodeset>]
+
+Options:
+ -l              list available playbooks
+ -p <playbook>   run the playbook
+ -n <nodeset>    list of target nodes, accept nodeset(1) patterns
+"
+}
+
+while getopts 'n:p:lh' p
+do
+    case $p in
+        n) nodeset=$OPTARG ;;
+        p) playbook=$OPTARG ;;
+        l) list=1 ;;
+        h) usage ; exit 0 ;;
+    esac
+done
+
+if [[ -n $list ]]; then
+    echo "List of playbooks available:"
+    ls -1 "${ANSIBLE_CONFIG}/playbooks/" | sed -n -e 's/\(.*\).yml/ - \1/p'
+    exit 0
+fi
+
+if [[ -z "$playbook" ]]; then
+    echo 'Error: You need to specify the playbook to run with `-p <playbook>`.'
+    usage
+    exit 1
+elif [[ ! -f "${ANSIBLE_CONFIG}/playbooks/${playbook}.yml" ]]; then
+    echo "Error: Playbook ${playbook} not found."
+    usage
+    exit 1
+fi
+
+ansbook_cmd=$(which ansible-playbook)
+if [[ $? -ne 0 ]]; then
+    echo 'Error: Cannot find command `ansible-playbook`.'
+    exit 1
+fi
+
+nodeset_cmd=$(which nodeset)
+if [[ $? -ne 0 ]]; then
+    echo 'Error: Cannot find command `nodeset`.'
+    exit 1
+fi
+
+if [[ -n "$nodeset" ]]; then
+    target="--extra-vars target=$(${nodeset_cmd} -e -S, ${nodeset})"
+fi
+
+echo $ansbook_cmd ${ANSIBLE_CONFIG}/playbooks/${playbook}.yml ${target}
+$ansbook_cmd ${ANSIBLE_CONFIG}/playbooks/${playbook}.yml ${target}

--- a/tools/bluebanquise-playbook
+++ b/tools/bluebanquise-playbook
@@ -5,24 +5,32 @@ export ANSIBLE_CONFIG=/etc/bluebanquise
 usage() {
     echo "Usage:
  $(basename $0) -l
- $(basename $0) -p <playbook> [-n <nodeset>]
+ $(basename $0) -p <playbook> [-n <nodeset>] [ansible-playbook parameters]
+
+Runs Ansible playbooks, executing the defined playbook on the targeted nodes.
 
 Options:
+ -h              print this help and exit
  -l              list available playbooks
  -p <playbook>   run the playbook
  -n <nodeset>    list of target nodes, accept nodeset(1) patterns
 "
 }
 
-while getopts 'n:p:lh' p
+PARAMS=("$@")
+while getopts ':n:p:lh-:' p "${PARAMS[@]}"
 do
-    case $p in
-        n) nodeset=$OPTARG ;;
-        p) playbook=$OPTARG ;;
+    case "$p" in
+        n) nodeset="$OPTARG" ;;
+        p) playbook="$OPTARG" ;;
         l) list=1 ;;
         h) usage ; exit 0 ;;
+        # Handle additional parameters to pass to ansible-playbook
+        -|*) ((OPTIND--)) ; break ;;
     esac
 done
+# Remaining parameters not parsed by getopts
+PARAMS=( "${PARAMS[@]:$OPTIND-1}" )
 
 if [[ -n $list ]]; then
     echo "List of playbooks available:"
@@ -56,5 +64,5 @@ if [[ -n "$nodeset" ]]; then
     target="--extra-vars target=$(${nodeset_cmd} -e -S, ${nodeset})"
 fi
 
-echo $ansbook_cmd ${ANSIBLE_CONFIG}/playbooks/${playbook}.yml ${target}
-$ansbook_cmd ${ANSIBLE_CONFIG}/playbooks/${playbook}.yml ${target}
+echo "Execute: $ansbook_cmd ${ANSIBLE_CONFIG}/playbooks/${playbook}.yml ${target} ${PARAMS[@]}"
+$ansbook_cmd ${ANSIBLE_CONFIG}/playbooks/${playbook}.yml ${target} ${PARAMS[@]}


### PR DESCRIPTION
```
Usage:
 bluebanquise-playbook -l
 bluebanquise-playbook -p <playbook> [-n <nodeset>] [ansible-playbook parameters]

Runs Ansible playbooks, executing the defined playbook on the targeted nodes.

Options:
 -h              print this help and exit
 -l              list available playbooks
 -p <playbook>   run the playbook
 -n <nodeset>    list of target nodes, accept nodeset(1) patterns
```
