### PR TITLE
fix: add support to enable and start services

### DIFF
--- a/roles/addons/nic_nmcli/tasks/main.yml
+++ b/roles/addons/nic_nmcli/tasks/main.yml
@@ -9,12 +9,22 @@
 #- name: Import packages OS dedicated task
 #  include_tasks: "{{ (ansible_distribution|lower) }}_{{ ansible_distribution_major_version }}.yml"
 
+- name: Enable/disable services
+  service:
+    name: "{{ item }}"
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  loop: "{{ services_to_start[(ansible_distribution|lower|replace(' ','_'))]['_'+ansible_distribution_major_version] }}"
+  tags:
+    - service
+
 - name: Start services
   service:
     name: "{{ item }}"
     state: started
-    enabled: yes
   loop: "{{ services_to_start[(ansible_distribution|lower|replace(' ','_'))]['_'+ansible_distribution_major_version] }}"
+  when: (start_services | bool)
+  tags:
+    - service
 
 - name: Solve possible unmanaged (Ubuntu only)
   file:
@@ -54,9 +64,19 @@
   tags:
     - identify
 
+- name: Enable/disable services
+  service:
+    name: "{{ item }}"
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  loop: "{{ services_to_start[(ansible_distribution|lower|replace(' ','_'))]['_'+ansible_distribution_major_version] }}"
+  tags:
+    - service
+
 - name: Start services
   service:
     name: "{{ item }}"
     state: restarted
-    enabled: yes
   loop: "{{ services_to_start[(ansible_distribution|lower|replace(' ','_'))]['_'+ansible_distribution_major_version] }}"
+  when: (start_services | bool)
+  tags:
+    - service

--- a/roles/addons/ofed/tasks/main.yml
+++ b/roles/addons/ofed/tasks/main.yml
@@ -11,8 +11,17 @@
     - libibumad
     - infiniband-diags
 
+- name: Enable/disable services
+  service:
+    name: rdma
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  tags:
+    - service
+
 - name: Start services
   service:
     name: rdma
     state: started
-    enabled: yes
+  when: (start_services | bool)
+  tags:
+    - service

--- a/roles/addons/ofed_sm/tasks/main.yml
+++ b/roles/addons/ofed_sm/tasks/main.yml
@@ -8,8 +8,17 @@
     - opensm
     - opensm-libs
 
+- name: Enable/disable services
+  service:
+    name: opensm
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  tags:
+    - service
+
 - name: Start services
   service:
     name: opensm
     state: started
-    enabled: yes
+  when: (start_services | bool)
+  tags:
+    - service

--- a/roles/addons/openldap_client/tasks/main.yml
+++ b/roles/addons/openldap_client/tasks/main.yml
@@ -20,12 +20,23 @@
     dest: /etc/sssd/sssd.conf
     mode: 0600
 
+- name: Enable/disable services
+  service:
+    name: "{{ item }}"
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  with_items:
+#    - nscd
+    - sssd
+  tags:
+    - service
+
 - name: Start services
   service:
     name: "{{ item }}"
     state: started
-    enabled: yes
   with_items:
 #    - nscd
     - sssd
-
+  when: (start_services | bool)
+  tags:
+    - service

--- a/roles/addons/openldap_server/tasks/main.yml
+++ b/roles/addons/openldap_server/tasks/main.yml
@@ -20,11 +20,20 @@
     group: ldap
   when: not db_config.stat.exists
 
+- name: Enable/disable services
+  service:
+    name: slapd
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  tags:
+    - service
+
 - name: Start ldap
   service:
     name: slapd
     state: started
-    enabled: yes
+  when: (start_services | bool)
+  tags:
+    - service
 
 - name: Template >> chdomain.ldif
   template:
@@ -119,12 +128,23 @@
     state: yes
     persistent: yes
 
+- name: Enable/disable services
+  service:
+    name: "{{ item }}"
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  with_items:
+    - slapd
+    - httpd
+  tags:
+    - service
+
 - name: Restart services
   service:
     name: "{{ item }}"
     state: restarted
-    enabled: yes
   with_items:
     - slapd
     - httpd
-
+  when: (start_services | bool)
+  tags:
+    - service

--- a/roles/addons/prometheus_client/tasks/main.yml
+++ b/roles/addons/prometheus_client/tasks/main.yml
@@ -6,12 +6,23 @@
     state: present
   when: "'node_exporter' in monitoring.exporters"
 
+- name: Enable/disable services
+  service:
+    name: node_exporter
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  when: "'node_exporter' in monitoring.exporters"
+  tags:
+    - service
+
 - name: Start services node_exporter
   service:
     name: node_exporter
     state: started
-    enabled: yes
-  when: "'node_exporter' in monitoring.exporters"
+  when:
+    - (start_services | bool)
+    - "'node_exporter' in monitoring.exporters"
+  tags:
+    - service
 
 - name: Package bb_exporter
   package:

--- a/roles/addons/prometheus_server/tasks/main.yml
+++ b/roles/addons/prometheus_server/tasks/main.yml
@@ -84,12 +84,25 @@
   tags:
     - template
 
-- name: Start services
+- name: Enable/disable services
   service:
     name: "{{ item }}"
-    state: started
-    enabled: yes
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
   with_items:
     - prometheus
     - alertmanager
     - ipmi_exporter
+  tags:
+    - service
+
+- name: Start services
+  service:
+    name: "{{ item }}"
+    state: started
+  with_items:
+    - prometheus
+    - alertmanager
+    - ipmi_exporter
+  when: (start_services | bool)
+  tags:
+    - service

--- a/roles/addons/slurm/tasks/main.yml
+++ b/roles/addons/slurm/tasks/main.yml
@@ -16,11 +16,20 @@
     group: munge
     mode: 0400
 
+- name: Enable/disable services >> munge
+  service:
+    name: munge
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  tags:
+    - service
+
 - name: Start services >> munge
   service:
     name: munge
     state: started
-    enabled: yes
+  when: (start_services | bool)
+  tags:
+    - service
 
 #### SLURM
 
@@ -70,17 +79,35 @@
     - /var/spool/slurmd/StateSave
     - /var/spool/slurmd/slurmd
 
-- name: Start services
+- name: Disable slurmctld
   service:
     name: slurmctld
-    state: started
     enabled: no         # Dangerous to enable slurm controller...
   when: slurm_profile == 'controller'
 
 - name: Start services
   service:
+    name: slurmctld
+    state: started
+  when:
+    - (start_services | bool)
+    - slurm_profile == 'controller'
+
+- name: Enable/disable services
+  service:
+    name: slurmd
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  when: slurm_profile == 'node'
+  tags:
+    - service
+
+- name: Start services
+  service:
     name: slurmd
     state: started
-    enabled: yes
-  when: slurm_profile == 'node'
+  when:
+    - (start_services | bool)
+    - slurm_profile == 'node'
+  tags:
+    - service
 

--- a/roles/advanced-core/advanced_dhcp_server/tasks/main.yml
+++ b/roles/advanced-core/advanced_dhcp_server/tasks/main.yml
@@ -43,10 +43,20 @@
   tags:
     - template
 
+- name: Enable/disable services
+  service:
+    name: "{{ item }}"
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  loop: "{{ services_to_start[(ansible_distribution|lower|replace(' ','_'))]['_'+ansible_distribution_major_version] }}"
+  tags:
+    - service
+
 - name: Start services
   service:
     name: "{{ item }}"
     state: started
-    enabled: yes
   loop: "{{ services_to_start[(ansible_distribution|lower|replace(' ','_'))]['_'+ansible_distribution_major_version] }}"
+  when: (start_services | bool)
+  tags:
+    - service
 

--- a/roles/core/dns_server/tasks/services_centos_7.yml
+++ b/roles/core/dns_server/tasks/services_centos_7.yml
@@ -1,5 +1,14 @@
+- name: Enable/disable services
+  service:
+    name: named
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  tags:
+    - service
+
 - name: Start services
   service:
     name: named
     state: started
-    enabled: yes
+  when: (start_services | bool)
+  tags:
+    - service

--- a/roles/core/dns_server/tasks/services_redhat_8.yml
+++ b/roles/core/dns_server/tasks/services_redhat_8.yml
@@ -1,5 +1,14 @@
+- name: Enable/disable services
+  service:
+    name: named
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  tags:
+    - service
+
 - name: Start services
   service:
     name: named
     state: started
-    enabled: yes
+  when: (start_services | bool)
+  tags:
+    - service

--- a/roles/core/dns_server/tasks/services_ubuntu_18.yml
+++ b/roles/core/dns_server/tasks/services_ubuntu_18.yml
@@ -1,5 +1,14 @@
+- name: Enable/disable services
+  service:
+    name: bind9
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  tags:
+    - service
+
 - name: Start services
   service:
     name: bind9
     state: started
-    enabled: yes
+  when: (start_services | bool)
+  tags:
+    - service

--- a/roles/core/nfs_client/tasks/main.yml
+++ b/roles/core/nfs_client/tasks/main.yml
@@ -18,12 +18,21 @@
     - groups[item.1] is defined and not none
     - inventory_hostname in groups[item.1]
 
+- name: Enable/disable services
+  service:
+    name: rpcbind
+    enabled: "{{ (enable_services | bool) | ternary('yes','no') }}"
+  when: (ansible_distribution|lower|replace(' ','_')) in ['centos','redhat']
+  tags:
+    - service
+
 - name: Start services
   service:
     name: rpcbind
     state: started
-    enabled: yes
-  when: (ansible_distribution|lower|replace(' ','_')) in ['centos','redhat']
+  when:
+    - (start_services | bool)
+    - (ansible_distribution|lower|replace(' ','_')) in ['centos','redhat']
   tags:
     - service
 


### PR DESCRIPTION
Most of the services should support the enable_services and
start_services parameters. Also add the tag service.

Closes #95