### PR TITLE
to delete

### DIFF
--- a/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
+++ b/roles/advanced-core/advanced_dhcp_server/templates/dhcpd.subnet.conf.j2
@@ -32,19 +32,20 @@
       {% set ipxe_embed = 'dhcpretry' %}
     {% else %}
       {% set ipxe_embed = 'standard' %}
-    {% endif %}
+    {% endif -%}
     {% if hostvars[host]['equipment_profile']['ipxe_platform'] == 'efi' %} {# Finally, build file name depending of platform and previous parameters #}
       {% set ipxe_rom_filename = (ipxe_architecture + '/' + ipxe_embed + '_' + ipxe_driver + 'ipxe.efi') %}
     {% else %}  {# Assume everything else is pcbios #}
       {% set ipxe_rom_filename = (ipxe_architecture + '/' + ipxe_embed + '_undionly.kpxe') %}
     {% endif %}
 
-    {% for nic, nic_args in hostvars[host]['network_interfaces'].items() %}
+    {%- for nic, nic_args in hostvars[host]['network_interfaces'].items() %}
       {% if (nic_args.network is defined and not none) and (nic_args.network == item) and (nic_args.ip4 is defined and not none) %}
         {% if nic_args.mac is defined and not none %}
-  host {{host}} { 
+
+  host {{host}} {
     option host-name "{{host}}";
-    hardware ethernet {{nic_args.mac}}; 
+    hardware ethernet {{nic_args.mac}};
     fixed-address {{nic_args.ip4}};
     filename "{{ipxe_rom_filename}}";
   }
@@ -76,12 +77,13 @@
   }
         {% endif %}
       {% endif %}
-    {% endfor %}
+    {% endfor -%}
 
     {% if hostvars[host]['bmc'] is defined %}
       {% set bmc_args = hostvars[host]['bmc'] %}
       {% if (bmc_args.network is defined and not none) and (bmc_args.network == item) and (bmc_args.name is defined and not none) and (bmc_args.ip4 is defined and not none) %}
         {% if bmc_args.mac is defined and not none %}
+
     host {{bmc_args.name}} {
       option host-name "{{bmc_args.name}}";
       hardware ethernet {{bmc_args.mac}};
@@ -115,4 +117,3 @@
     {% endif %}
   {% endif %}
 {% endfor %}
-


### PR DESCRIPTION
Hello,
When we define several networks (ice1-2, ice1-3, ...) , the dhcpd.subnet.conf.j2 template generate many trailing whitespace in DHPC configuration files.
This is not a problem to run the DHCP service, but the configuration files generate is too big and not very clean.

For fix this issue, please merge my patch.

Regards,